### PR TITLE
fix: apply attributes after a reset in a sequence

### DIFF
--- a/lua/ansi/parser.lua
+++ b/lua/ansi/parser.lua
@@ -55,7 +55,14 @@ function M.parse_ansi_sequence(sequence)
 
   for _, code in ipairs(codes) do
     if code == 0 then
-      attrs.reset = true
+      attrs = {
+        fg = nil,
+        bg = nil,
+        bold = false,
+        italic = false,
+        underline = false,
+        reset = true,
+      }
     elseif code == 1 then
       attrs.bold = true
     elseif code == 3 then

--- a/lua/ansi/renderer.lua
+++ b/lua/ansi/renderer.lua
@@ -49,11 +49,11 @@ function M.apply_ansi_highlighting(bufnr)
         -- Update current attributes
         if seq.attrs.reset then
           current_attrs = {}
-        else
-          for k, v in pairs(seq.attrs) do
-            if k ~= 'reset' and v then
-              current_attrs[k] = v
-            end
+        end
+
+        for k, v in pairs(seq.attrs) do
+          if k ~= 'reset' and v then
+            current_attrs[k] = v
           end
         end
 


### PR DESCRIPTION
It has a bug where a sequence like `<esc>[0;32m` would just apply the reset command (`0`), and ignore the subsequent color command `32`.