### PR TITLE
fix: support foreground and background ANSI reset codes

### DIFF
--- a/lua/ansi/parser.lua
+++ b/lua/ansi/parser.lua
@@ -69,6 +69,10 @@ function M.parse_ansi_sequence(sequence)
       attrs.italic = true
     elseif code == 4 then
       attrs.underline = true
+    elseif code == 39 then
+      attrs.fg = '__reset__'
+    elseif code == 49 then
+      attrs.bg = '__reset__'
     elseif M.colors[code] then
       attrs.fg = M.colors[code]
     elseif M.bg_colors[code] then

--- a/test_ansi_real.txt
+++ b/test_ansi_real.txt
@@ -1,40 +1,54 @@
 Test file for ansi.nvim plugin with real ANSI sequences
 
 === Basic Colors ===
-[31mThis is red text[0m
-[32mThis is green text[0m  
-[33mThis is yellow text[0m
-[34mThis is blue text[0m
-[35mThis is magenta text[0m
-[36mThis is cyan text[0m
-[37mThis is white text[0m
+[31mRed text[0m
+[32mGreen text[0m
+[33mYellow text[0m
+[34mBlue text[0m
+[35mMagenta text[0m
+[36mCyan text[0m
+[37mWhite text[0m
 
 === Bright Colors ===
-This is bright red text
-This is bright green text
-This is bright yellow text
-This is bright blue text
-This is bright magenta text
-This is bright cyan text
-This is bright white text
+[91mBright red text[0m
+[92mBright green text[0m
+[93mBright yellow text[0m
+[94mBright blue text[0m
+[95mBright magenta text[0m
+[96mBright cyan text[0m
+[97mBright white text[0m
+
+=== Background Colors ===
+[41mRed background[0m
+[42mGreen background[0m
+[43mYellow background[0m
+[44mBlue background[0m
+[45mMagenta background[0m
+[46mCyan background[0m
+[47mWhite background[0m
 
 === Text Attributes ===
-This is bold text
-This is italic text
-This is underlined text
-This is bold and italic
-This is bold and underlined
+[1mBold text[0m
+[3mItalic text[0m
+[4mUnderlined text[0m
+[1;3mBold and italic[0m
+[1;4mBold and underlined[0m
 
 === Combined Colors and Attributes ===
-This is bold red text
-This is italic green text
-This is underlined blue text
-Yellow text on red background
-White text on blue background
-Bold red text on green background
+[31;1mBold red text[0m
+[32;3mItalic green text[0m
+[34;4mUnderlined blue text[0m
+[33;41mYellow text on red background[0m
+[97;44mWhite text on blue background[0m
+[1;31;42mBold red text on green background[0m
 
 === Multiple sequences on one line ===
-Red Green Blue Bold Italic
+[31mRed[0m [32mGreen[0m [34mBlue[0m [1mBold[0m [3mItalic[0m
+
+=== Reset Sequences
+[31mRed text[0m reset formatting [94mBright blue text[0m
+[33;41mYellow on red [39mreset foreground only[0m reset all
+[33;41mYellow on red [49mreset background only[0m reset all
 
 === Complex example ===
-ERROR: Warning message - Success! (timestamp: 2024-01-01)
+[1;31mERROR:[0m [33mWarning message[0m - [32mSuccess![0m [90m(timestamp: 2024-01-01)[0m Unformatted text

--- a/tests/run_tests.lua
+++ b/tests/run_tests.lua
@@ -49,6 +49,28 @@ local function run_parser_tests()
     assert(attrs.fg == 'red', "Should parse red foreground")
     assert(attrs.bg == 'green', "Should parse green background")
   end)
+
+  test("parse foreground reset code", function()
+    local attrs = parser.parse_ansi_sequence('39')
+    assert(attrs.fg == '__reset__', "Should parse foreground reset code")
+  end)
+
+  test("parse background reset code", function()
+    local attrs = parser.parse_ansi_sequence('49')
+    assert(attrs.bg == '__reset__', "Should parse background reset code")
+  end)
+
+  test("parse combined codes with foreground reset", function()
+    local attrs = parser.parse_ansi_sequence('33;41;39')
+    assert(attrs.fg == '__reset__', "Should reset foreground")
+    assert(attrs.bg == 'red', "Should preserve red background")
+  end)
+
+  test("parse combined codes with background reset", function()
+    local attrs = parser.parse_ansi_sequence('33;41;49')
+    assert(attrs.fg == 'yellow', "Should preserve yellow foreground")
+    assert(attrs.bg == '__reset__', "Should reset background")
+  end)
   
   -- Test find_ansi_sequences
   test("find single sequence", function()
@@ -65,6 +87,17 @@ local function run_parser_tests()
     assert(#sequences == 4, "Should find 4 sequences")
     assert(sequences[1].attrs.fg == 'red', "Should find red")
     assert(sequences[3].attrs.fg == 'green', "Should find green")
+  end)
+
+  test("find partial reset sequences", function()
+    local text = '\27[33;41mYellow on red\27[39m default fg\27[49m default bg\27[0m'
+    local sequences = parser.find_ansi_sequences(text)
+    assert(#sequences == 4, "Should find 4 sequences")
+    assert(sequences[1].attrs.fg == 'yellow', "Should find yellow foreground")
+    assert(sequences[1].attrs.bg == 'red', "Should find red background")
+    assert(sequences[2].attrs.fg == '__reset__', "Should find foreground reset")
+    assert(sequences[3].attrs.bg == '__reset__', "Should find background reset")
+    assert(sequences[4].attrs.reset == true, "Should find final reset")
   end)
   
   test("handle plain text", function()


### PR DESCRIPTION
I have a terminal app and I'm using [39m as a reset code instead of just [0m. This adds both [39m (foreground) and [49m (background) resets.