### PR TITLE
Fix/conceallevel not retrievable

### DIFF
--- a/lua/ansi/init.lua
+++ b/lua/ansi/init.lua
@@ -35,7 +35,7 @@ end
 
 function M.toggle(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
-  local conceallevel = vim.api.nvim_buf_get_option(bufnr, 'conceallevel')
+  local conceallevel = vim.wo.conceallevel
 
   if conceallevel > 0 then
     M.disable(bufnr)

--- a/lua/ansi/renderer.lua
+++ b/lua/ansi/renderer.lua
@@ -113,7 +113,7 @@ end
 function M.disable_for_buffer(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   M.clear_buffer_highlights(bufnr)
-  vim.api.nvim_create_augroup('AnsiColors_' .. bufnr, { clear = true })
+  pcall(vim.api.nvim_clear_autocmds, { group = 'AnsiColors_' .. bufnr })
   vim.api.nvim_buf_call(bufnr, function()
     vim.wo.conceallevel = 0
   end)

--- a/lua/ansi/renderer.lua
+++ b/lua/ansi/renderer.lua
@@ -98,7 +98,9 @@ function M.enable_for_buffer(bufnr, theme)
   M.setup_syntax_matching(bufnr)
   M.apply_ansi_highlighting(bufnr)
 
+  local group = vim.api.nvim_create_augroup('AnsiColors_' .. bufnr, { clear = true })
   vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
+    group = group,
     buffer = bufnr,
     callback = function()
       vim.defer_fn(function()
@@ -111,6 +113,7 @@ end
 function M.disable_for_buffer(bufnr)
   bufnr = bufnr or vim.api.nvim_get_current_buf()
   M.clear_buffer_highlights(bufnr)
+  vim.api.nvim_create_augroup('AnsiColors_' .. bufnr, { clear = true })
   vim.api.nvim_buf_call(bufnr, function()
     vim.wo.conceallevel = 0
   end)


### PR DESCRIPTION
Fixes 2 issues:
1. on nvim v0.11.6 (nvim 0.9+ I believe), `nvim_get_option_value` no longer lets you retrieve `conceallevel` (deprecated behavior and breaking issue)
   - now uses `vim.wo.conceallevel` to read conceallevel which matches how we write `conceallevel`. It's available since v0.5 and should be compatible with versions 0.8+ listed in the CI pipeline
2. Multiple autocmds were being created when `:AnsiEnable` more than once in a window. 
   - now creates an augroup so we don't create duplicates